### PR TITLE
ci: add publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout commit
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build new version
+        run: |
+          npm version ${{ github.event.release.tag_name }}
+          npm run build
+
+      - name: Publish version
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,16 @@
 
 - Run tests with `npm run test`
 - Write new tests for your changes. For new functionality, add it to the [harness](tests/integration/harness) and cover with integration tests
-- Write commit messages that follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
+- Write commit messages and PR titles that follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
 - Write commits, comments and documentation in English
 
 ## Publishing
 
-New version number is determined by [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) based on the commit history.
+To publish a new version, [create a new release](https://github.com/nerestjs/nerest/releases/new) on GitHub. The release will automatically trigger a new version to be published to npm.
+
+- Click "Generate release notes" to pull the list of all merged PRs into the changelog
+- Put a release tag in the title, following semantic versioning, based on the merged PRs
+- Click "Publish release"
 
 ## Issues
 


### PR DESCRIPTION
Adds a Github Workflow that publishes a new version of Nerest to NPM when a release is created through Github UI.

This is a bit different from previous approach, where a new release was created for every merge into main. But this approach is taken by most open source npm packages and allows us to bundle multiple changes into a single release, as well as comfortably develop multiple major branches at once if necessary.