### PR TITLE
chore: update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,16 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'sunday'
+      day: 'monday'
+    cooldown:
+      default-days: 14
     groups:
+      minor-updates:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
       fastify:
         patterns:
           - 'fastify'
@@ -28,9 +36,3 @@ updates:
           - 'react-dom'
           - '@types/react'
           - '@types/react-dom'
-      minor-updates:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=14


### PR DESCRIPTION
I propose an update to the Dependabot settings:

- Move execution from Sunday to Monday to get emails and notifications during work week
- Prioritize minor updates group to only extract major vite, fastify and react updates into separate PRs
- Introduce a 14 day cooldown to match security policy and apply Dependabot updates without newer transitive dependencies