### PR TITLE
Use Fastify reply.headers for CORS in development static handler

### DIFF
--- a/server/development.ts
+++ b/server/development.ts
@@ -86,13 +86,13 @@ export async function runDevelopmentServer(port: number) {
 
     // Set CORS headers so the development server assets can be accessed from
     // remote devices, e.g. mobile phones
-    setHeaders(res) {
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', 'GET');
-      res.setHeader(
-        'Access-Control-Allow-Headers',
-        'X-Requested-With, content-type, Authorization'
-      );
+    setHeaders(reply) {
+      reply.headers({
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET',
+        'Access-Control-Allow-Headers':
+          'X-Requested-With, content-type, Authorization',
+      });
     },
   });
 


### PR DESCRIPTION
### Motivation
- Use the Fastify reply API to set CORS headers for static assets instead of direct `res.setHeader` calls so headers are applied correctly in the Fastify development server.

### Description
- Rename `setHeaders(res)` to `setHeaders(reply)` and replace `res.setHeader(...)` calls with a single `reply.headers({...})` call in `server/development.ts`.

### Testing
- Ran TypeScript typecheck with `tsc --noEmit` and the project test suite with `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a670d0ca3a083258293fcf9c26c370c)