### PR TITLE
feat: add `nerest/preload.ts` hook and `nerest start` cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,30 @@ export function logger(): FastifyServerOptions['logger'] {
 
 To disable the logger, return `false` from the function.
 
+### Preload
+
+If the module `nerest/preload.ts` exists in the micro frontend's root directory, it is built into a standalone `build/preload.mjs` bundle and loaded via Node's `--import` flag **before** the server bundle when the server is started with [`nerest start`](#nerest-start). This means its top-level code runs before any framework or application module is imported - the right place to register instrumentation or apply patches to modules that will be imported by main application code.
+
+The module may additionally export optional `startup` and `shutdown` handlers. `startup` runs as early as possible during server start, and `shutdown` runs late during graceful shutdown - useful for flushing buffered work. Both may be async.
+
+```typescript
+// nerest/preload.ts
+
+// Top-level code runs before the server is imported.
+registerMyInstrumentation();
+
+export async function startup() {
+  console.log('Server is starting up');
+}
+
+export async function shutdown() {
+  // e.g. flush buffered spans before the process exits
+  await myInstrumentation.shutdown();
+}
+```
+
+Because `--import` is what guarantees the preload runs first, the server must be launched with `nerest start` for this ordering to hold. If `nerest/preload.ts` is absent, no preload bundle is produced and `nerest start` behaves like a plain server launch.
+
 ### Preview
 
 For customizing micro frontend previews, create a `nerest/preview-head.html` file in the project's root directory. This file allows you to modify the preview rendering by appending your own HTML markup, such as metadata, external stylesheets, or scripts to the end of the `<head>`. Use it to to enhance the appearance and behavior of previews according to your specific needs.
@@ -172,6 +196,7 @@ Creates the production build of the micro frontend, generating the necessary fil
 
 - Serverside entry is outputted to the `build/server.mjs` file.
 - Clientside static files are outputted to the `build/client/assets` directory. These files should be made available [at the `STATIC_PATH` URL](#static_path).
+- If a [`nerest/preload.ts`](#preload) module exists, it is outputted to the `build/preload.mjs` file.
 
 ### `nerest typegen`
 
@@ -186,6 +211,14 @@ nerest typegen 'apps/*/schema.json' 'schemas/*.json'
 ### `nerest watch`
 
 Starts the development server on the default port 3000. The server will automatically reload when changes are made to the app's source code.
+
+### `nerest start`
+
+Starts the production server previously produced by `nerest build`, listening on the port from the `PORT` environment variable (default 3000). If a [`build/preload.mjs`](#preload) bundle exists, it is loaded via `node --import` before the server so its instrumentation runs first. Termination signals are forwarded so graceful shutdown runs, making this the recommended production entrypoint:
+
+```dockerfile
+CMD ["npx", "nerest", "start"]
+```
 
 ## Development
 

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -5,6 +5,7 @@ import 'dotenv/config';
 import { build } from './build.js';
 import { typegen } from './typegen.js';
 import { watch } from './watch.js';
+import { start } from './start.js';
 
 // TODO: add CLI help and manual, maybe use a CLI framework like oclif
 async function cliEntry(args: string[]) {
@@ -14,6 +15,8 @@ async function cliEntry(args: string[]) {
     await typegen(args.slice(1));
   } else if (args[0] === 'watch') {
     await watch();
+  } else if (args[0] === 'start') {
+    await start();
   }
 }
 

--- a/bin/start.ts
+++ b/bin/start.ts
@@ -5,11 +5,11 @@ import { pathToFileURL } from 'url';
 
 const SERVER_ENTRY = path.join('build', 'server.mjs');
 
+export async function start() {
+  spawnServer(resolveStartArgs());
+}
+
 // Resolve the arguments passed to `node` when starting the production server.
-// If a preload bundle was produced (i.e. the micro frontend has a
-// `nerest/preload.ts`), it is `--import`ed before the server entry so that its
-// top-level code runs first — this is what lets instrumentation libraries
-// patch modules before the server imports them.
 export function resolveStartArgs(root: string = process.cwd()): string[] {
   const preloadBundle = path.join(root, 'build', 'preload.mjs');
 
@@ -21,13 +21,13 @@ export function resolveStartArgs(root: string = process.cwd()): string[] {
   return [SERVER_ENTRY];
 }
 
-// Start the production server. Spawns `node` (optionally preloading the
-// instrumentation bundle) as a child process and forwards termination signals
-// so that graceful shutdown — and the preload's `shutdown` handler — run.
-export async function start() {
-  const args = resolveStartArgs();
-
-  const child = spawn(process.execPath, args, { stdio: 'inherit' });
+// Spawn `node` with the given args as a child process, forwarding termination
+// signals so that graceful shutdown runs.
+export function spawnServer(args: string[], env?: NodeJS.ProcessEnv) {
+  const child = spawn(process.execPath, args, {
+    stdio: 'inherit',
+    env: { ...process.env, ...env },
+  });
 
   const forwardSignal = (signal: NodeJS.Signals) => {
     if (!child.killed) {
@@ -52,4 +52,6 @@ export async function start() {
       process.exit(code ?? 0);
     }
   });
+
+  return child;
 }

--- a/bin/start.ts
+++ b/bin/start.ts
@@ -35,10 +35,16 @@ export async function start() {
     }
   };
 
-  process.on('SIGTERM', () => forwardSignal('SIGTERM'));
-  process.on('SIGINT', () => forwardSignal('SIGINT'));
+  const forwardSigterm = () => forwardSignal('SIGTERM');
+  const forwardSigint = () => forwardSignal('SIGINT');
+
+  process.on('SIGTERM', forwardSigterm);
+  process.on('SIGINT', forwardSigint);
 
   child.on('exit', (code, signal) => {
+    process.off('SIGTERM', forwardSigterm);
+    process.off('SIGINT', forwardSigint);
+
     if (signal) {
       // Re-raise the signal so our exit status reflects how the child died.
       process.kill(process.pid, signal);

--- a/bin/start.ts
+++ b/bin/start.ts
@@ -1,0 +1,49 @@
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const SERVER_ENTRY = path.join('build', 'server.mjs');
+
+// Resolve the arguments passed to `node` when starting the production server.
+// If a preload bundle was produced (i.e. the micro frontend has a
+// `nerest/preload.ts`), it is `--import`ed before the server entry so that its
+// top-level code runs first — this is what lets instrumentation libraries
+// patch modules before the server imports them.
+export function resolveStartArgs(root: string = process.cwd()): string[] {
+  const preloadBundle = path.join(root, 'build', 'preload.mjs');
+
+  if (existsSync(preloadBundle)) {
+    // `--import` expects a module specifier; a file URL is the portable form.
+    return ['--import', pathToFileURL(preloadBundle).href, SERVER_ENTRY];
+  }
+
+  return [SERVER_ENTRY];
+}
+
+// Start the production server. Spawns `node` (optionally preloading the
+// instrumentation bundle) as a child process and forwards termination signals
+// so that graceful shutdown — and the preload's `shutdown` handler — run.
+export async function start() {
+  const args = resolveStartArgs();
+
+  const child = spawn(process.execPath, args, { stdio: 'inherit' });
+
+  const forwardSignal = (signal: NodeJS.Signals) => {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  };
+
+  process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+  process.on('SIGINT', () => forwardSignal('SIGINT'));
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      // Re-raise the signal so our exit status reflects how the child died.
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 0);
+    }
+  });
+}

--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -1,8 +1,37 @@
+import { existsSync } from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
 import { runDevelopmentServer } from '../server/development.js';
+import { buildPreloadBundle } from '../build/preload.js';
+import { spawnServer } from './start.js';
+
+const PRELOAD_SOURCE_ENTRY = path.join('nerest', 'preload.ts');
+
+// Set on the re-launched child so it runs the dev server instead of
+// recursively rebuilding and re-launching the preload bundle.
+const WATCH_CHILD_ENV = 'NEREST_WATCH_CHILD';
 
 // Start dev server in watch mode, that restarts on file change
-// and rebuilds the client static files
+// and rebuilds the client static files.
 export async function watch() {
+  const root = process.cwd();
+
+  // If the micro frontend has a `nerest/preload.ts`, we build it and re-launch
+  // ourselves in a child `node` that `--import`s the bundle before anything else.
+  if (!process.env[WATCH_CHILD_ENV] && existsSync(PRELOAD_SOURCE_ENTRY)) {
+    await buildPreloadBundle(root, '/');
+
+    const preloadBundle = pathToFileURL(
+      path.join(root, 'build', 'preload.mjs')
+    ).href;
+
+    spawnServer(['--import', preloadBundle, process.argv[1], 'watch'], {
+      [WATCH_CHILD_ENV]: '1',
+    });
+    return;
+  }
+
   console.log('Starting Nerest watch...');
   await runDevelopmentServer(
     process.env.PORT ? Number(process.env.PORT) : 3000

--- a/build/configs/production.ts
+++ b/build/configs/production.ts
@@ -64,3 +64,26 @@ export async function viteConfigProductionServer(
     plugins: [react()],
   };
 }
+
+export async function viteConfigProductionPreload(
+  args: BuildArgs
+): Promise<InlineConfig> {
+  return {
+    ...(await viteConfigShared(args)),
+    build: {
+      emptyOutDir: false,
+      modulePreload: false,
+      ssr: true,
+      rolldownOptions: {
+        input: '/nerest/preload.ts',
+        output: {
+          dir: 'build',
+          entryFileNames: `preload.mjs`,
+          chunkFileNames: `preload-[name].mjs`,
+          assetFileNames: `preload-[name].[ext]`,
+        },
+      },
+    },
+    plugins: [react()],
+  };
+}

--- a/build/index.ts
+++ b/build/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
 
 import { build } from 'vite';
 
@@ -11,6 +12,7 @@ import { loadProject } from '../server/loaders/project.js';
 import {
   viteConfigProductionClient,
   viteConfigProductionServer,
+  viteConfigProductionPreload,
 } from './configs/production.js';
 
 export async function buildMicroFrontend() {
@@ -51,6 +53,21 @@ export async function buildMicroFrontend() {
   });
   console.log('Producing production server build...');
   await build(serverViteConfig);
+
+  // Build the optional preload bundle if `nerest/preload.ts` exists. It is
+  // emitted as a standalone `build/preload.mjs` so it can be `--import`ed
+  // before the server (see `nerest start`).
+  if (existsSync(path.join(root, 'nerest/preload.ts'))) {
+    const preloadViteConfig = await viteConfigProductionPreload({
+      root,
+      base: staticPath,
+      buildConfig,
+      project,
+      appDirectories,
+    });
+    console.log('Producing production preload build...');
+    await build(preloadViteConfig);
+  }
 }
 
 async function createNerestManifest(

--- a/build/index.ts
+++ b/build/index.ts
@@ -12,8 +12,8 @@ import { loadProject } from '../server/loaders/project.js';
 import {
   viteConfigProductionClient,
   viteConfigProductionServer,
-  viteConfigProductionPreload,
 } from './configs/production.js';
+import { buildPreloadBundle } from './preload.js';
 
 export async function buildMicroFrontend() {
   const root = process.cwd();
@@ -54,19 +54,9 @@ export async function buildMicroFrontend() {
   console.log('Producing production server build...');
   await build(serverViteConfig);
 
-  // Build the optional preload bundle if `nerest/preload.ts` exists. It is
-  // emitted as a standalone `build/preload.mjs` so it can be `--import`ed
-  // before the server (see `nerest start`).
+  // Build the optional preload bundle if it exists
   if (existsSync(path.join(root, 'nerest/preload.ts'))) {
-    const preloadViteConfig = await viteConfigProductionPreload({
-      root,
-      base: staticPath,
-      buildConfig,
-      project,
-      appDirectories,
-    });
-    console.log('Producing production preload build...');
-    await build(preloadViteConfig);
+    await buildPreloadBundle(root, staticPath);
   }
 }
 

--- a/build/preload.ts
+++ b/build/preload.ts
@@ -1,0 +1,22 @@
+import { build } from 'vite';
+
+import { loadBuildConfig } from '../server/loaders/build.js';
+import { loadAppDirectories } from '../server/loaders/directories.js';
+import { loadProject } from '../server/loaders/project.js';
+import { viteConfigProductionPreload } from './configs/production.js';
+
+export async function buildPreloadBundle(root: string, base: string) {
+  const buildConfig = await loadBuildConfig(root);
+  const project = await loadProject(root);
+  const appDirectories = await loadAppDirectories(root);
+
+  const preloadViteConfig = await viteConfigProductionPreload({
+    root,
+    base,
+    buildConfig,
+    project,
+    appDirectories,
+  });
+  console.log('Producing preload build...');
+  await build(preloadViteConfig);
+}

--- a/server/development.ts
+++ b/server/development.ts
@@ -1,5 +1,7 @@
 // This is the nerest development server entrypoint
 import path from 'path';
+import { existsSync } from 'fs';
+import { pathToFileURL } from 'url';
 import { build, createServer as createViteServer } from 'vite';
 import type { InlineConfig } from 'vite';
 import type { RolldownWatcher, RolldownWatcherEvent } from 'rolldown';
@@ -59,6 +61,12 @@ export async function runDevelopmentServer(port: number) {
   // Load app entries following the `apps/{name}/index.tsx` convention
   const apps = await loadApps(root, appDirectories, staticPath);
 
+  // The preload bundle is built and `--import`ed before this server by
+  // `nerest watch`, so its top-level code has already run. Here we import that
+  // same module to reach its optional startup/shutdown handlers; the cached
+  // instance is returned without re-running its side effects.
+  const preloadBundle = path.join(root, 'build', 'preload.mjs');
+
   const app = await createServer({
     root,
     project,
@@ -73,12 +81,12 @@ export async function runDevelopmentServer(port: number) {
     loadPropsHook: (entry: string) =>
       viteSsr.ssrLoadModule(`/apps/${entry}/props.ts`),
     loadRuntimeHook: () => viteSsr.ssrLoadModule('/nerest/runtime.ts'),
-    // There is no separate preload bundle in development, so we load the
-    // source module directly. Its startup/shutdown handlers still run, but its
-    // top-level code executes here rather than before the server, which is
-    // fine for local development.
-    loadPreloadHook: () =>
-      viteSsr.ssrLoadModule('/nerest/preload.ts').catch(() => undefined),
+    loadPreloadHook: async () =>
+      existsSync(preloadBundle)
+        ? import(/* @vite-ignore */ pathToFileURL(preloadBundle).href).catch(
+            () => undefined
+          )
+        : undefined,
   });
 
   // Register middie to use vite's Connect-style middlewares

--- a/server/development.ts
+++ b/server/development.ts
@@ -73,6 +73,12 @@ export async function runDevelopmentServer(port: number) {
     loadPropsHook: (entry: string) =>
       viteSsr.ssrLoadModule(`/apps/${entry}/props.ts`),
     loadRuntimeHook: () => viteSsr.ssrLoadModule('/nerest/runtime.ts'),
+    // There is no separate preload bundle in development, so we load the
+    // source module directly. Its startup/shutdown handlers still run, but its
+    // top-level code executes here rather than before the server, which is
+    // fine for local development.
+    loadPreloadHook: () =>
+      viteSsr.ssrLoadModule('/nerest/preload.ts').catch(() => undefined),
   });
 
   // Register middie to use vite's Connect-style middlewares

--- a/server/hooks/preload.ts
+++ b/server/hooks/preload.ts
@@ -1,0 +1,57 @@
+import type { FastifyBaseLogger } from 'fastify';
+
+type PreloadHookModule = {
+  startup?: () => unknown;
+  shutdown?: () => unknown;
+};
+
+// Load the preload module, tolerating its absence. Unlike the runtime hook,
+// the preload module lives in a separate bundle that is `--import`ed before
+// the server (see `nerest start`), so here we only reach for its optional
+// `startup`/`shutdown` lifecycle handlers.
+async function loadPreloadModule(
+  loader: () => Promise<unknown>
+): Promise<PreloadHookModule | undefined> {
+  try {
+    return (await loader()) as PreloadHookModule;
+  } catch {
+    return undefined;
+  }
+}
+
+// Run the preload module's `startup` handler, if it exports one. Called as
+// early as possible during server start.
+export async function runPreloadStartupHook(
+  logger: FastifyBaseLogger,
+  loader: () => Promise<unknown>
+) {
+  const module = await loadPreloadModule(loader);
+
+  if (typeof module?.startup === 'function') {
+    try {
+      await module.startup();
+      logger.info('Preload startup hook executed');
+    } catch (e) {
+      logger.fatal(e, 'Failed to execute preload startup hook');
+      process.exit(1);
+    }
+  }
+}
+
+// Run the preload module's `shutdown` handler, if it exports one. Called late
+// during graceful shutdown.
+export async function runPreloadShutdownHook(
+  logger: FastifyBaseLogger,
+  loader: () => Promise<unknown>
+) {
+  const module = await loadPreloadModule(loader);
+
+  if (typeof module?.shutdown === 'function') {
+    try {
+      await module.shutdown();
+      logger.info('Preload shutdown hook executed');
+    } catch (e) {
+      logger.error(e, 'Failed to execute preload shutdown hook');
+    }
+  }
+}

--- a/server/production.ts
+++ b/server/production.ts
@@ -1,4 +1,7 @@
 // This is the nerest production server entrypoint
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 import type { ComponentType } from 'react';
 import { createServer } from './shared.js';
 import { loadNerestManifest } from './loaders/manifest.js';
@@ -22,6 +25,17 @@ async function runProductionServer(port: number) {
 
   const runtimeHook = import.meta.glob('/nerest/runtime.ts', { eager: true });
 
+  // The preload hook is intentionally NOT globbed into this bundle. It is built
+  // as a standalone `build/preload.mjs` (sibling to this file) so it can be
+  // `--import`ed before the server (see `nerest start`). Here we dynamically
+  // import that same module URL to reach its optional startup/shutdown
+  // handlers; when it was `--import`ed, this returns the cached instance
+  // without re-running its top-level side effects.
+  const preloadBundle = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'preload.mjs'
+  );
+
   const app = await createServer({
     root,
     project,
@@ -31,6 +45,10 @@ async function runProductionServer(port: number) {
     loadPropsHook: async (entry: string) =>
       propsHooks[`/apps/${entry}/props.ts`],
     loadRuntimeHook: async () => runtimeHook['/nerest/runtime.ts'],
+    loadPreloadHook: async () =>
+      existsSync(preloadBundle)
+        ? import(/* @vite-ignore */ pathToFileURL(preloadBundle).href)
+        : undefined,
   });
 
   await app.listen({

--- a/server/shared.ts
+++ b/server/shared.ts
@@ -11,6 +11,10 @@ import { setupK8SProbes } from './parts/k8s-probes.js';
 import { runRuntimeHook } from './hooks/runtime.js';
 import { runPropsHook } from './hooks/props.js';
 import { runLoggerHook } from './hooks/logger.js';
+import {
+  runPreloadStartupHook,
+  runPreloadShutdownHook,
+} from './hooks/preload.js';
 import type { Project } from './loaders/project.js';
 import { loadPreviewParts } from './loaders/preview.js';
 import type { PreviewParts } from './loaders/preview.js';
@@ -24,6 +28,7 @@ type ServerOptions = {
   loadComponent: (entry: string) => Promise<ComponentType>;
   loadPropsHook: (entry: string) => Promise<unknown>;
   loadRuntimeHook: () => Promise<unknown>;
+  loadPreloadHook: () => Promise<unknown>;
 };
 
 type ServerOptionsWithPreview = ServerOptions & {
@@ -31,7 +36,7 @@ type ServerOptionsWithPreview = ServerOptions & {
 };
 
 export async function createServer(options: ServerOptions) {
-  const { project, root, loadRuntimeHook } = options;
+  const { project, root, loadRuntimeHook, loadPreloadHook } = options;
 
   const app = fastify({
     logger: (await runLoggerHook(loadRuntimeHook)) ?? true,
@@ -47,6 +52,10 @@ export async function createServer(options: ServerOptions) {
     },
   });
 
+  // Execute the preload hook's `startup` handler as early as possible, before
+  // any routes or plugins are set up
+  await runPreloadStartupHook(app.log, loadPreloadHook);
+
   // Setup payload validation and Swagger based on apps' JSON Schema
   setupValidator(app);
   await setupSwagger(app, project);
@@ -58,6 +67,14 @@ export async function createServer(options: ServerOptions) {
 
   // Add graceful shutdown handler to prevent requests errors
   await app.register(fastifyGracefulShutdown);
+
+  // Run the preload hook's `shutdown` handler late in the shutdown sequence
+  app.after((err) => {
+    if (err) throw err;
+    app.gracefulShutdown(async () => {
+      await runPreloadShutdownHook(app.log, loadPreloadHook);
+    });
+  });
 
   if (process.env.ENABLE_K8S_PROBES) {
     await setupK8SProbes(app);

--- a/tests/integration/harness/nerest/preload.ts
+++ b/tests/integration/harness/nerest/preload.ts
@@ -1,0 +1,26 @@
+// Preload hook used by the integration harness to verify that Nerest bundles
+// and runs `nerest/preload.ts` before the server. State is recorded on
+// globalThis so it can be surfaced over HTTP by nerest/runtime.ts.
+
+type PreloadState = {
+  imported?: boolean;
+  startup?: boolean;
+  shutdown?: boolean;
+};
+
+(globalThis as any).__NEREST_PRELOAD__ ??= {};
+const state: PreloadState = (globalThis as any).__NEREST_PRELOAD__;
+
+// Top-level side effect: runs when the module is imported (via `--import` in
+// production, or on first load in development).
+state.imported = true;
+
+export function startup() {
+  state.startup = true;
+  console.log('PRELOAD_STARTUP_OK');
+}
+
+export function shutdown() {
+  state.shutdown = true;
+  console.log('PRELOAD_SHUTDOWN_OK');
+}

--- a/tests/integration/harness/nerest/runtime.ts
+++ b/tests/integration/harness/nerest/runtime.ts
@@ -1,0 +1,14 @@
+import type { FastifyInstance } from 'fastify';
+
+// Exposes the preload hook state (recorded by nerest/preload.ts) over HTTP so
+// integration tests can assert that the preload module was imported and its
+// startup handler ran inside the live server.
+export default function (app: FastifyInstance) {
+  app.get('/preload-status', { logLevel: 'silent' }, async () => {
+    const state = (globalThis as any).__NEREST_PRELOAD__ ?? {};
+    return {
+      imported: Boolean(state.imported),
+      startup: Boolean(state.startup),
+    };
+  });
+}

--- a/tests/integration/run.production.sh
+++ b/tests/integration/run.production.sh
@@ -19,7 +19,7 @@ STATIC_PATH=http://127.0.0.1:3000 npm run build
 
 # Start production server
 echo "Starting production server..."
-ENABLE_K8S_PROBES=true node build/server.mjs > /tmp/nerest-prod-server.log 2>&1 &
+ENABLE_K8S_PROBES=true npx nerest start > /tmp/nerest-prod-server.log 2>&1 &
 SERVER_PID=$!
 
 # Wait for server to be ready

--- a/tests/integration/suites/preload.test.ts
+++ b/tests/integration/suites/preload.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { BASE_URL } from '../constants.js';
+
+describe('Preload hook', () => {
+  it('imports the preload module and runs its startup handler', async () => {
+    const response = await fetch(`${BASE_URL}/preload-status`);
+
+    expect(response.status).toBe(200);
+
+    const status = await response.json();
+
+    // The preload module's top-level code ran...
+    expect(status.imported).toBe(true);
+    // ...and its startup handler was invoked during server start.
+    expect(status.startup).toBe(true);
+  });
+});

--- a/tests/module/bin/start.test.ts
+++ b/tests/module/bin/start.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { resolveStartArgs } from '../../../bin/start.js';
+
+describe('resolveStartArgs', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'nerest-start-'));
+    await fs.mkdir(path.join(root, 'build'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('should start the server directly when no preload bundle exists', () => {
+    expect(resolveStartArgs(root)).toEqual([path.join('build', 'server.mjs')]);
+  });
+
+  it('should --import the preload bundle when it exists', async () => {
+    const preloadBundle = path.join(root, 'build', 'preload.mjs');
+    await fs.writeFile(preloadBundle, '// preload', 'utf-8');
+
+    expect(resolveStartArgs(root)).toEqual([
+      '--import',
+      pathToFileURL(preloadBundle).href,
+      path.join('build', 'server.mjs'),
+    ]);
+  });
+});

--- a/tests/module/hooks/preload.test.ts
+++ b/tests/module/hooks/preload.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runPreloadStartupHook,
+  runPreloadShutdownHook,
+} from '../../../server/hooks/preload.js';
+
+describe('preload hooks', () => {
+  const mockLogger = {
+    fatal: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  } as any;
+  const mockLoader = vi.fn();
+  const mockProcessExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('process.exit called');
+  });
+
+  describe('runPreloadStartupHook', () => {
+    it('should execute the startup handler if the module exports one', async () => {
+      const startup = vi.fn();
+      mockLoader.mockResolvedValue({ startup });
+
+      await runPreloadStartupHook(mockLogger, mockLoader);
+
+      expect(startup).toHaveBeenCalledOnce();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Preload startup hook executed'
+      );
+    });
+
+    it('should do nothing if the module does not export a startup handler', async () => {
+      mockLoader.mockResolvedValue({ shutdown: vi.fn() });
+
+      await runPreloadStartupHook(mockLogger, mockLoader);
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+      expect(mockProcessExit).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing if the module does not exist', async () => {
+      mockLoader.mockRejectedValue(new Error('not found'));
+
+      await runPreloadStartupHook(mockLogger, mockLoader);
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+      expect(mockProcessExit).not.toHaveBeenCalled();
+    });
+
+    it('should log a fatal error and exit if the startup handler throws', async () => {
+      const error = new Error('Error in startup');
+      mockLoader.mockResolvedValue({
+        startup: () => {
+          throw error;
+        },
+      });
+
+      await expect(
+        runPreloadStartupHook(mockLogger, mockLoader)
+      ).rejects.toThrowError('process.exit called');
+
+      expect(mockLogger.fatal).toHaveBeenCalledWith(
+        error,
+        'Failed to execute preload startup hook'
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('runPreloadShutdownHook', () => {
+    it('should execute the shutdown handler if the module exports one', async () => {
+      const shutdown = vi.fn();
+      mockLoader.mockResolvedValue({ shutdown });
+
+      await runPreloadShutdownHook(mockLogger, mockLoader);
+
+      expect(shutdown).toHaveBeenCalledOnce();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Preload shutdown hook executed'
+      );
+    });
+
+    it('should do nothing if the module does not export a shutdown handler', async () => {
+      mockLoader.mockResolvedValue({ startup: vi.fn() });
+
+      await runPreloadShutdownHook(mockLogger, mockLoader);
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+    });
+
+    it('should log an error but not exit if the shutdown handler throws', async () => {
+      const error = new Error('Error in shutdown');
+      mockLoader.mockResolvedValue({
+        shutdown: () => {
+          throw error;
+        },
+      });
+
+      await runPreloadShutdownHook(mockLogger, mockLoader);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        error,
+        'Failed to execute preload shutdown hook'
+      );
+      expect(mockProcessExit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/module/server-setup.test.ts
+++ b/tests/module/server-setup.test.ts
@@ -5,6 +5,10 @@ import type { AppEntry } from '../../server/loaders/apps.js';
 import { loadPreviewParts } from '../../server/loaders/preview.js';
 import { runLoggerHook } from '../../server/hooks/logger.js';
 import { runRuntimeHook } from '../../server/hooks/runtime.js';
+import {
+  runPreloadStartupHook,
+  runPreloadShutdownHook,
+} from '../../server/hooks/preload.js';
 import { setupValidator } from '../../server/parts/validator.js';
 import { setupSwagger } from '../../server/parts/swagger.js';
 import { setupK8SProbes } from '../../server/parts/k8s-probes.js';
@@ -14,8 +18,12 @@ vi.mock('fastify', () => ({
     register: vi.fn(),
     post: vi.fn(),
     get: vi.fn(),
+    after: vi.fn((cb) => cb()),
+    gracefulShutdown: vi.fn(),
     log: {
       error: vi.fn(),
+      info: vi.fn(),
+      fatal: vi.fn(),
     },
   })),
 }));
@@ -24,6 +32,7 @@ vi.mock('fastify-graceful-shutdown');
 vi.mock('../../server/loaders/preview.js');
 vi.mock('../../server/hooks/logger.js');
 vi.mock('../../server/hooks/runtime.js');
+vi.mock('../../server/hooks/preload.js');
 vi.mock('../../server/parts/validator.js');
 vi.mock('../../server/parts/swagger.js');
 vi.mock('../../server/parts/k8s-probes.js');
@@ -59,6 +68,7 @@ describe('server setup', () => {
   const mockLoadComponent = vi.fn();
   const mockLoadPropsHook = vi.fn();
   const mockLoadRuntimeHook = vi.fn();
+  const mockLoadPreloadHook = vi.fn();
 
   it('should create server with correct configuration', async () => {
     const server = await createServer({
@@ -68,6 +78,7 @@ describe('server setup', () => {
       loadComponent: mockLoadComponent,
       loadPropsHook: mockLoadPropsHook,
       loadRuntimeHook: mockLoadRuntimeHook,
+      loadPreloadHook: mockLoadPreloadHook,
     });
 
     expect(server).toBeDefined();
@@ -77,6 +88,22 @@ describe('server setup', () => {
     expect(loadPreviewParts).toHaveBeenCalledWith('/test');
     expect(server.register).toHaveBeenCalledWith(fastifyGracefulShutdown);
     expect(runRuntimeHook).toHaveBeenCalledWith(server, mockLoadRuntimeHook);
+
+    // Preload startup runs early with the app logger and preload loader
+    expect(runPreloadStartupHook).toHaveBeenCalledWith(
+      server.log,
+      mockLoadPreloadHook
+    );
+
+    // Preload shutdown is wired into graceful shutdown: the registered
+    // handler, when invoked, runs the shutdown hook
+    expect(server.gracefulShutdown).toHaveBeenCalledWith(expect.any(Function));
+    const shutdownHandler = (server.gracefulShutdown as any).mock.calls[0][0];
+    await shutdownHandler();
+    expect(runPreloadShutdownHook).toHaveBeenCalledWith(
+      server.log,
+      mockLoadPreloadHook
+    );
   });
 
   it('should setup API routes for each app', async () => {
@@ -87,6 +114,7 @@ describe('server setup', () => {
       loadComponent: mockLoadComponent,
       loadPropsHook: mockLoadPropsHook,
       loadRuntimeHook: mockLoadRuntimeHook,
+      loadPreloadHook: mockLoadPreloadHook,
     });
 
     expect(server.post).toHaveBeenCalledWith(
@@ -113,6 +141,7 @@ describe('server setup', () => {
       loadComponent: mockLoadComponent,
       loadPropsHook: mockLoadPropsHook,
       loadRuntimeHook: mockLoadRuntimeHook,
+      loadPreloadHook: mockLoadPreloadHook,
     });
 
     expect(server.get).toHaveBeenCalledWith(
@@ -135,6 +164,7 @@ describe('server setup', () => {
       loadComponent: mockLoadComponent,
       loadPropsHook: mockLoadPropsHook,
       loadRuntimeHook: mockLoadRuntimeHook,
+      loadPreloadHook: mockLoadPreloadHook,
     });
 
     expect(server.log.error).toHaveBeenCalledWith(
@@ -159,6 +189,7 @@ describe('server setup', () => {
         loadComponent: mockLoadComponent,
         loadPropsHook: mockLoadPropsHook,
         loadRuntimeHook: mockLoadRuntimeHook,
+        loadPreloadHook: mockLoadPreloadHook,
       });
 
       expect(setupK8SProbes).toHaveBeenCalledWith(server);
@@ -174,6 +205,7 @@ describe('server setup', () => {
         loadComponent: mockLoadComponent,
         loadPropsHook: mockLoadPropsHook,
         loadRuntimeHook: mockLoadRuntimeHook,
+        loadPreloadHook: mockLoadPreloadHook,
       });
 
       expect(setupK8SProbes).not.toHaveBeenCalled();


### PR DESCRIPTION
To add Open Telemetry instrumentation to Nerest micro frontends, we need an extension point that lets the developer execute code before the main application's module graph is loaded and executed. We also want to keep this extension point generic enough so that it can be used for different purposes.

This PR implements a `nerest/preload.ts` hook, which compiles into a separate module that gets loaded early by node's `--import` argument. This feature can be used for instrumentation, or any other purpose that requires executing code before main application loads, for example for runtime patching of modules.

It also introduces an optional `nerest start` cli command, which can be used to start a built Nerest micro frontend, including the preload module if it has one. 
