### PR TITLE
refactor: optimize nerest binary RAM usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,16 @@ Starts the development server on the default port 3000. The server will automati
 
 ### `nerest start`
 
-Starts the production server previously produced by `nerest build`, listening on the port from the `PORT` environment variable (default 3000). If a [`build/preload.mjs`](#preload) bundle exists, it is loaded via `node --import` before the server so its instrumentation runs first. Termination signals are forwarded so graceful shutdown runs, making this the recommended production entrypoint:
+Starts the production server previously produced by `nerest build`, listening on the port from the `PORT` environment variable (default 3000). This is the recommended production entrypoint:
 
 ```dockerfile
 CMD ["npx", "nerest", "start"]
+```
+
+If a [`build/preload.mjs`](#preload) bundle exists, it is loaded via `node --import` before the server so its instrumentation runs first. If you'd like to avoid an extra resident process, use this entrypoint:
+
+```dockerfile
+CMD ["node", "--import", "./build/preload.mjs", "./build/server.mjs"]
 ```
 
 ## Development

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -2,20 +2,19 @@
 // All executions of `nerest <command>` get routed through here
 import 'dotenv/config';
 
-import { build } from './build.js';
-import { typegen } from './typegen.js';
-import { watch } from './watch.js';
-import { start } from './start.js';
-
 // TODO: add CLI help and manual, maybe use a CLI framework like oclif
 async function cliEntry(args: string[]) {
   if (args[0] === 'build') {
+    const { build } = await import('./build.js');
     await build();
   } else if (args[0] === 'typegen') {
+    const { typegen } = await import('./typegen.js');
     await typegen(args.slice(1));
   } else if (args[0] === 'watch') {
+    const { watch } = await import('./watch.js');
     await watch();
   } else if (args[0] === 'start') {
+    const { start } = await import('./start.js');
     await start();
   }
 }

--- a/bin/start.ts
+++ b/bin/start.ts
@@ -5,20 +5,36 @@ import { pathToFileURL } from 'url';
 
 const SERVER_ENTRY = path.join('build', 'server.mjs');
 
+export type StartPlan =
+  | { mode: 'in-process'; entry: string }
+  | { mode: 'spawn'; args: string[] };
+
 export async function start() {
-  spawnServer(resolveStartArgs());
+  const plan = resolveStartPlan();
+
+  if (plan.mode === 'in-process') {
+    await import(pathToFileURL(plan.entry).href);
+    return;
+  }
+
+  spawnServer(plan.args);
 }
 
-// Resolve the arguments passed to `node` when starting the production server.
-export function resolveStartArgs(root: string = process.cwd()): string[] {
+// Decide how to launch the production server.
+export function resolveStartPlan(root: string = process.cwd()): StartPlan {
   const preloadBundle = path.join(root, 'build', 'preload.mjs');
 
   if (existsSync(preloadBundle)) {
-    // `--import` expects a module specifier; a file URL is the portable form.
-    return ['--import', pathToFileURL(preloadBundle).href, SERVER_ENTRY];
+    // `--import` is what guarantees the preload's top-level code runs before
+    // the server's module graph.
+    return {
+      mode: 'spawn',
+      args: ['--import', pathToFileURL(preloadBundle).href, SERVER_ENTRY],
+    };
   }
 
-  return [SERVER_ENTRY];
+  // Without preload there's no need for a child process.
+  return { mode: 'in-process', entry: path.join(root, SERVER_ENTRY) };
 }
 
 // Spawn `node` with the given args as a child process, forwarding termination

--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -1,10 +1,15 @@
+import { spawn } from 'child_process';
 import { existsSync } from 'fs';
 import path from 'path';
-import { pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 import { spawnServer } from './start.js';
 
 const PRELOAD_SOURCE_ENTRY = path.join('nerest', 'preload.ts');
+
+const PRELOAD_BUILDER_ENTRY = fileURLToPath(
+  new URL('../build/preload-cli.js', import.meta.url)
+);
 
 // Set on the re-launched child so it runs the dev server instead of
 // recursively rebuilding and re-launching the preload bundle.
@@ -18,8 +23,7 @@ export async function watch() {
   // If the micro frontend has a `nerest/preload.ts`, we build it and re-launch
   // ourselves in a child `node` that `--import`s the bundle before anything else.
   if (!process.env[WATCH_CHILD_ENV] && existsSync(PRELOAD_SOURCE_ENTRY)) {
-    const { buildPreloadBundle } = await import('../build/preload.js');
-    await buildPreloadBundle(root, '/');
+    await buildPreloadBundleInChildProcess(root, '/');
 
     const preloadBundle = pathToFileURL(
       path.join(root, 'build', 'preload.mjs')
@@ -37,4 +41,28 @@ export async function watch() {
   await runDevelopmentServer(
     process.env.PORT ? Number(process.env.PORT) : 3000
   );
+}
+
+// Build the preload bundle in a throwaway `node`, so that the Vite instance it
+// needs is freed on exit rather than retained for the lifetime of this process.
+export function buildPreloadBundleInChildProcess(root: string, base: string) {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(process.execPath, [PRELOAD_BUILDER_ENTRY, root, base], {
+      stdio: 'inherit',
+    });
+
+    child.on('error', reject);
+
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `Preload build failed with ${signal ? `signal ${signal}` : `exit code ${code}`}`
+          )
+        );
+      }
+    });
+  });
 }

--- a/bin/watch.ts
+++ b/bin/watch.ts
@@ -2,8 +2,6 @@ import { existsSync } from 'fs';
 import path from 'path';
 import { pathToFileURL } from 'url';
 
-import { runDevelopmentServer } from '../server/development.js';
-import { buildPreloadBundle } from '../build/preload.js';
 import { spawnServer } from './start.js';
 
 const PRELOAD_SOURCE_ENTRY = path.join('nerest', 'preload.ts');
@@ -20,6 +18,7 @@ export async function watch() {
   // If the micro frontend has a `nerest/preload.ts`, we build it and re-launch
   // ourselves in a child `node` that `--import`s the bundle before anything else.
   if (!process.env[WATCH_CHILD_ENV] && existsSync(PRELOAD_SOURCE_ENTRY)) {
+    const { buildPreloadBundle } = await import('../build/preload.js');
     await buildPreloadBundle(root, '/');
 
     const preloadBundle = pathToFileURL(
@@ -33,6 +32,8 @@ export async function watch() {
   }
 
   console.log('Starting Nerest watch...');
+
+  const { runDevelopmentServer } = await import('../server/development.js');
   await runDevelopmentServer(
     process.env.PORT ? Number(process.env.PORT) : 3000
   );

--- a/build/preload-cli.ts
+++ b/build/preload-cli.ts
@@ -1,0 +1,8 @@
+// Internal entrypoint, spawned by `nerest watch`. Building the preload bundle
+// pulls in Vite, so it happens in a throwaway process that frees it on exit
+// instead of in the long-lived parent.
+import { buildPreloadBundle } from './preload.js';
+
+const [root, base] = process.argv.slice(2);
+
+await buildPreloadBundle(root, base);

--- a/tests/module/bin/start.test.ts
+++ b/tests/module/bin/start.test.ts
@@ -3,9 +3,9 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { resolveStartArgs } from '../../../bin/start.js';
+import { resolveStartPlan } from '../../../bin/start.js';
 
-describe('resolveStartArgs', () => {
+describe('resolveStartPlan', () => {
   let root: string;
 
   beforeEach(async () => {
@@ -17,18 +17,24 @@ describe('resolveStartArgs', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it('should start the server directly when no preload bundle exists', () => {
-    expect(resolveStartArgs(root)).toEqual([path.join('build', 'server.mjs')]);
+  it('should run the server in-process when no preload bundle exists', () => {
+    expect(resolveStartPlan(root)).toEqual({
+      mode: 'in-process',
+      entry: path.join(root, 'build', 'server.mjs'),
+    });
   });
 
-  it('should --import the preload bundle when it exists', async () => {
+  it('should spawn a child that --imports the preload bundle when it exists', async () => {
     const preloadBundle = path.join(root, 'build', 'preload.mjs');
     await fs.writeFile(preloadBundle, '// preload', 'utf-8');
 
-    expect(resolveStartArgs(root)).toEqual([
-      '--import',
-      pathToFileURL(preloadBundle).href,
-      path.join('build', 'server.mjs'),
-    ]);
+    expect(resolveStartPlan(root)).toEqual({
+      mode: 'spawn',
+      args: [
+        '--import',
+        pathToFileURL(preloadBundle).href,
+        path.join('build', 'server.mjs'),
+      ],
+    });
   });
 });

--- a/tests/module/bin/watch.test.ts
+++ b/tests/module/bin/watch.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import { buildPreloadBundleInChildProcess } from '../../../bin/watch.js';
+
+vi.mock('child_process');
+
+// Stands in for the spawned builder, so tests can drive its exit.
+function mockChildProcess() {
+  const child = new EventEmitter();
+  vi.mocked(spawn).mockReturnValue(child as never);
+  return child;
+}
+
+describe('buildPreloadBundleInChildProcess', () => {
+  beforeEach(() => {
+    vi.mocked(spawn).mockReset();
+  });
+
+  it('should build the bundle in a separate node process', async () => {
+    const child = mockChildProcess();
+
+    const built = buildPreloadBundleInChildProcess('/project', '/');
+    child.emit('exit', 0, null);
+
+    await expect(built).resolves.toBeUndefined();
+    expect(spawn).toHaveBeenCalledWith(
+      process.execPath,
+      [expect.stringContaining('preload-cli'), '/project', '/'],
+      { stdio: 'inherit' }
+    );
+  });
+
+  it('should reject when the build exits with a non-zero code', async () => {
+    const child = mockChildProcess();
+
+    const built = buildPreloadBundleInChildProcess('/project', '/');
+    child.emit('exit', 1, null);
+
+    await expect(built).rejects.toThrow('exit code 1');
+  });
+
+  it('should reject when the build is killed by a signal', async () => {
+    const child = mockChildProcess();
+
+    const built = buildPreloadBundleInChildProcess('/project', '/');
+    child.emit('exit', null, 'SIGKILL');
+
+    await expect(built).rejects.toThrow('signal SIGKILL');
+  });
+
+  it('should reject when the process cannot be spawned', async () => {
+    const child = mockChildProcess();
+
+    const built = buildPreloadBundleInChildProcess('/project', '/');
+    child.emit('error', new Error('ENOENT'));
+
+    await expect(built).rejects.toThrow('ENOENT');
+  });
+});


### PR DESCRIPTION
After introducing preload functionality, I've noticed that the RAM footprint of the nerest binary, especially `nerest watch` and `nerest start` has increased significantly. In some cases, with a heavy `nerest/preload.ts` module, the watch command used over 1 GB of RAM.

I ran some optimizations with Claude Code, primarily lazy loading of modules and exiting Vite processes when they are no longer needed.

Before and after measured on the harness:

| command               | main                | branch              | change   |
| --------------------- | ------------------- | ------------------- | -------- |
| `start`, no preload   | **206 MB** | **92 MB**  | **−55%** |
| `start`, with preload | **207 MB** | **138 MB** | **−33%** |
| `watch`, no preload   | **157 MB** | **145 MB** | **−8%**  |
| `watch`, with preload | **294 MB** | **194 MB** | **−34%** |
| `build`               | **176 MB** | **151 MB** | **−14%** |
| `typegen`             | **123 MB** | **83 MB**  | **−33%** |

It's about 30% improvement for the heaviest cases of start and watch with preload, likely more if the preload module itself is heavier.